### PR TITLE
Use int32_t instead of long for COFF headers when available

### DIFF
--- a/src/inc/coff/aouthdr.h
+++ b/src/inc/coff/aouthdr.h
@@ -7,18 +7,24 @@
 
 /* #ident	"@(#)sgs-inc:common/aouthdr.h	1.4" */
 
+#if __STDC__
+#include <stdint.h>
+#else
+typedef long int32_t;
+#endif
+
 typedef	struct aouthdr {
 	short	magic;		/* see magic.h				*/
 	short	vstamp;		/* version stamp			*/
-	long	tsize;		/* text size in bytes, padded to FW
+	int32_t	tsize;		/* text size in bytes, padded to FW
 				   bdry					*/
-	long	dsize;		/* initialized data "  "		*/
-	long	bsize;		/* uninitialized data "   "		*/
+	int32_t	dsize;		/* initialized data "  "		*/
+	int32_t	bsize;		/* uninitialized data "   "		*/
 #if U3B
-	long	dum1;
-	long	dum2;		/* pad to entry point	*/
+	int32_t	dum1;
+	int32_t	dum2;		/* pad to entry point	*/
 #endif
-	long	entry;		/* entry pt.				*/
-	long	text_start;	/* base of text used for this file	*/
-	long	data_start;	/* base of data used for this file	*/
+	int32_t	entry;		/* entry pt.				*/
+	int32_t	text_start;	/* base of text used for this file	*/
+	int32_t	data_start;	/* base of data used for this file	*/
 } AOUTHDR;

--- a/src/inc/coff/filehdr.h
+++ b/src/inc/coff/filehdr.h
@@ -9,12 +9,18 @@
 /*
  */
 
+#if __STDC__
+#include <stdint.h>
+#else
+typedef long int32_t;
+#endif
+
 struct filehdr {
 	unsigned short	f_magic;	/* magic number */
 	unsigned short	f_nscns;	/* number of sections */
-	long		f_timdat;	/* time & date stamp */
-	long		f_symptr;	/* file pointer to symtab */
-	long		f_nsyms;	/* number of symtab entries */
+	int32_t		f_timdat;	/* time & date stamp */
+	int32_t		f_symptr;	/* file pointer to symtab */
+	int32_t		f_nsyms;	/* number of symtab entries */
 	unsigned short	f_opthdr;	/* sizeof(optional hdr) */
 	unsigned short	f_flags;	/* flags */
 	};

--- a/src/inc/coff/reloc.h
+++ b/src/inc/coff/reloc.h
@@ -9,9 +9,15 @@
 /*
  */
 
+#if __STDC__
+#include <stdint.h>
+#else
+typedef long int32_t;
+#endif
+
 struct reloc {
-	long	r_vaddr;	/* (virtual) address of reference */
-	long	r_symndx;	/* index into symbol table */
+	int32_t	r_vaddr;	/* (virtual) address of reference */
+	int32_t	r_symndx;	/* index into symbol table */
 	unsigned short	r_type;		/* relocation type */
 	};
 

--- a/src/inc/coff/scnhdr.h
+++ b/src/inc/coff/scnhdr.h
@@ -9,17 +9,23 @@
 /*
  */
 
+#if __STDC__
+#include <stdint.h>
+#else
+typedef long int32_t;
+#endif
+
 struct scnhdr {
 	char		s_name[8];	/* section name */
-	long		s_paddr;	/* physical address, aliased s_nlib */
-	long		s_vaddr;	/* virtual address */
-	long		s_size;		/* section size */
-	long		s_scnptr;	/* file ptr to raw data for section */
-	long		s_relptr;	/* file ptr to relocation */
-	long		s_lnnoptr;	/* file ptr to line numbers */
+	int32_t		s_paddr;	/* physical address, aliased s_nlib */
+	int32_t		s_vaddr;	/* virtual address */
+	int32_t		s_size;		/* section size */
+	int32_t		s_scnptr;	/* file ptr to raw data for section */
+	int32_t		s_relptr;	/* file ptr to relocation */
+	int32_t		s_lnnoptr;	/* file ptr to line numbers */
 	unsigned short	s_nreloc;	/* number of relocation entries */
 	unsigned short	s_nlnno;	/* number of line number entries */
-	long		s_flags;	/* flags */
+	int32_t		s_flags;	/* flags */
 	};
 
 /* the number of shared libraries in a .lib section in an absolute output file


### PR DESCRIPTION
This needed to make dmdld work on 64-bit hosts